### PR TITLE
refactor: GetExperienciaLaboralByPersona para solucionar problema de concurrencia

### DIFF
--- a/services/experiencia_laboral.service.go
+++ b/services/experiencia_laboral.service.go
@@ -314,7 +314,7 @@ func GetExperienciaLaboralByPersona(idTercero string) (APIResponseDTO requestres
 			wge.SetLimit(-1)
 			for _, Data := range DataMap {
 				Data := Data
-				wge.Go(func () error{
+				wge.Go(func() error {
 					var experiencia map[string]interface{}
 					resultadoAux := make(map[string]interface{})
 					if err := json.Unmarshal([]byte(Data["Dato"].(string)), &experiencia); err == nil {
@@ -327,60 +327,71 @@ func GetExperienciaLaboralByPersona(idTercero string) (APIResponseDTO requestres
 						resultadoAux["FechaFinalizacion"] = experiencia["FechaFinalizacion"]
 						resultadoAux["FechaInicio"] = experiencia["FechaInicio"]
 						resultadoAux["Nit"] = experiencia["Nit"]
-	
+
 						if reflect.TypeOf(experiencia["Nit"]).Kind() == reflect.Float64 {
 							experiencia["Nit"] = fmt.Sprintf("%.f", experiencia["Nit"])
 						}
-	
-						var endpoit string
+
+						var endpoint string
 						if strings.Contains(fmt.Sprintf("%v", experiencia["Nit"]), "-") {
 							var auxNit = strings.Split(fmt.Sprintf("%v", experiencia["Nit"]), "-")
-							endpoit = "datos_identificacion?query=TipoDocumentoId__Id:7,Numero:" + auxNit[0] + ",DigitoVerificacion:" + auxNit[1]
+							endpoint = "datos_identificacion?query=TipoDocumentoId__Id:7,Numero:" + auxNit[0] + ",DigitoVerificacion:" + auxNit[1]
 						} else {
-							endpoit = "datos_identificacion?query=TipoDocumentoId__Id:7,Numero:" + fmt.Sprintf("%v", experiencia["Nit"])
+							endpoint = "datos_identificacion?query=TipoDocumentoId__Id:7,Numero:" + fmt.Sprintf("%v", experiencia["Nit"])
 						}
-	
-						errDatosIdentificacion := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+endpoit, &empresa)
+
+						errDatosIdentificacion := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+endpoint, &empresa)
 						if errDatosIdentificacion == nil {
 							if empresa != nil && len(empresa[0]) > 0 {
 								idEmpresa := empresa[0]["TerceroId"].(map[string]interface{})["Id"]
-	
-								//GET que trae la información de la empresa
+
+								// GET que trae la información de la empresa
 								errEmpresa := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+"tercero/"+fmt.Sprintf("%v", idEmpresa), &empresaTercero)
 								if errEmpresa == nil && fmt.Sprintf("%v", empresaTercero["System"]) != "map[]" && empresaTercero["Id"] != nil {
 									if empresaTercero["Status"] != "400" {
+										mutex.Lock()
 										resultadoAux["NombreEmpresa"] = map[string]interface{}{
 											"Id":             idEmpresa,
 											"NombreCompleto": empresaTercero["NombreCompleto"],
 										}
+										mutex.Unlock()
+
 										var lugar map[string]interface{}
-										//GET para traer los datos de la ubicación
+										// GET para traer los datos de la ubicación
 										errLugar := request.GetJson("http://"+beego.AppConfig.String("UbicacionesService")+"/relacion_lugares/jerarquia_lugar/"+fmt.Sprintf("%v", empresaTercero["LugarOrigen"]), &lugar)
 										if errLugar == nil && fmt.Sprintf("%v", lugar) != "map[]" {
 											if lugar["Status"] != "404" {
+												mutex.Lock()
 												resultadoAux["Ubicacion"] = map[string]interface{}{
 													"Id":     lugar["PAIS"].(map[string]interface{})["Id"],
 													"Nombre": lugar["PAIS"].(map[string]interface{})["Nombre"],
 												}
-	
-												//GET para traer la dirección de la empresa (info_complementaria 54)
+												mutex.Unlock()
+
+												// GET para traer la dirección de la empresa (info_complementaria 54)
 												var resultadoDireccion []map[string]interface{}
 												errDireccion := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+"info_complementaria_tercero?limit=1&query=Activo:true,InfoComplementariaId__Id:54,TerceroId:"+fmt.Sprintf("%.f", idEmpresa), &resultadoDireccion)
 												if errDireccion == nil && fmt.Sprintf("%v", resultadoDireccion[0]["System"]) != "map[]" {
 													if resultadoDireccion[0]["Status"] != "404" && resultadoDireccion[0]["Id"] != nil {
 														var direccionJSON map[string]interface{}
 														if err := json.Unmarshal([]byte(resultadoDireccion[0]["Dato"].(string)), &direccionJSON); err != nil {
+															mutex.Lock()
 															resultadoAux["Direccion"] = nil
+															mutex.Unlock()
 														} else {
+															mutex.Lock()
 															resultadoAux["Direccion"] = direccionJSON["address"]
+															mutex.Unlock()
 														}
 													} else {
+														mutex.Lock()
 														resultadoAux["Direccion"] = nil
+														mutex.Unlock()
 													}
 												} else {
 													return errDireccion
 												}
-	
+
 												// GET para traer el telefono de la empresa (info_complementaria 51)
 												var resultadoTelefono []map[string]interface{}
 												errTelefono := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+"info_complementaria_tercero?limit=1&query=Activo:true,InfoComplementariaId__Id:51,TerceroId:"+fmt.Sprintf("%.f", idEmpresa), &resultadoTelefono)
@@ -388,17 +399,23 @@ func GetExperienciaLaboralByPersona(idTercero string) (APIResponseDTO requestres
 													if resultadoTelefono[0]["Status"] != "404" && resultadoTelefono[0]["Id"] != nil {
 														var telefonoJSON map[string]interface{}
 														if err := json.Unmarshal([]byte(resultadoTelefono[0]["Dato"].(string)), &telefonoJSON); err != nil {
+															mutex.Lock()
 															resultadoAux["Telefono"] = nil
+															mutex.Unlock()
 														} else {
+															mutex.Lock()
 															resultadoAux["Telefono"] = telefonoJSON["telefono"]
+															mutex.Unlock()
 														}
 													} else {
+														mutex.Lock()
 														resultadoAux["Telefono"] = nil
+														mutex.Unlock()
 													}
 												} else {
 													return errTelefono
 												}
-	
+
 												// GET para traer el correo de la empresa (info_complementaria 53)
 												var resultadoCorreo []map[string]interface{}
 												errCorreo := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+"info_complementaria_tercero?limit=1&query=Activo:true,InfoComplementariaId__Id:53,TerceroId:"+fmt.Sprintf("%.f", idEmpresa), &resultadoCorreo)
@@ -406,62 +423,77 @@ func GetExperienciaLaboralByPersona(idTercero string) (APIResponseDTO requestres
 													if resultadoCorreo[0]["Status"] != "404" && resultadoCorreo[0]["Id"] != nil {
 														var correoJSON map[string]interface{}
 														if err := json.Unmarshal([]byte(resultadoCorreo[0]["Dato"].(string)), &correoJSON); err != nil {
+															mutex.Lock()
 															resultadoAux["Correo"] = nil
+															mutex.Unlock()
 														} else {
+															mutex.Lock()
 															resultadoAux["Correo"] = correoJSON["email"]
+															mutex.Unlock()
 														}
 													} else {
+														mutex.Lock()
 														resultadoAux["Correo"] = nil
+														mutex.Unlock()
 													}
 												} else {
 													return errCorreo
 												}
-	
+
 												// GET para traer la organizacion de la empresa (info_complementaria 110)
 												var resultadoOrganizacion []map[string]interface{}
 												errorganizacion := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+"tercero_tipo_tercero/?limit=1&query=TerceroId__Id:"+fmt.Sprintf("%.f", idEmpresa), &resultadoOrganizacion)
 												if errorganizacion == nil && fmt.Sprintf("%v", resultadoOrganizacion[0]["System"]) != "map[]" {
 													if resultadoOrganizacion[0]["Status"] != "404" && resultadoOrganizacion[0]["Id"] != nil {
-	
+														mutex.Lock()
 														resultadoAux["TipoTerceroId"] = map[string]interface{}{
 															"Id":     resultadoOrganizacion[0]["TipoTerceroId"].(map[string]interface{})["Id"],
 															"Nombre": resultadoOrganizacion[0]["TipoTerceroId"].(map[string]interface{})["Nombre"],
 														}
+														mutex.Unlock()
 													} else {
+														mutex.Lock()
 														resultadoAux["TipoTerceroId"] = nil
+														mutex.Unlock()
 													}
 												} else {
 													return errorganizacion
 												}
-	
+
 											} else {
+												mutex.Lock()
 												resultadoAux["Ubicacion"] = nil
 												resultadoAux["Direccion"] = nil
 												resultadoAux["Telefono"] = nil
 												resultadoAux["Correo"] = nil
 												resultadoAux["TipoTerceroId"] = nil
+												mutex.Unlock()
 											}
 										} else {
 											return errLugar
 										}
 									} else {
+										mutex.Lock()
 										resultadoAux["NombreCompleto"] = nil
 										resultadoAux["Ubicacion"] = nil
 										resultadoAux["Direccion"] = nil
 										resultadoAux["Telefono"] = nil
 										resultadoAux["Correo"] = nil
 										resultadoAux["TipoTerceroId"] = nil
+										mutex.Unlock()
 									}
 								} else {
 									return errEmpresa
 								}
 							} else {
+								mutex.Lock()
 								resultadoAux["NombreEmpresa"] = nil
 								resultadoAux["Ubicacion"] = nil
 								resultadoAux["Direccion"] = nil
 								resultadoAux["Telefono"] = nil
 								resultadoAux["Correo"] = nil
 								resultadoAux["TipoTerceroId"] = nil
+								mutex.Unlock()
 							}
 						} else {
 							return errDatosIdentificacion

--- a/services/formacion.service.go
+++ b/services/formacion.service.go
@@ -425,68 +425,66 @@ func GetFormacionAcademicaByIdTercero(idTercero string) (APIResponseDTO requestr
 	wge := new(errgroup.Group)
 	var mutex sync.Mutex // Mutex para proteger el acceso a resultados
 
-
 	errData := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+"info_complementaria_tercero?query=TerceroId__Id:"+idTercero+",InfoComplementariaId__CodigoAbreviacion:FORM_ACADEMICA,Activo:true&limit=0&sortby=Id&order=asc", &DataMap)
 	if errData == nil {
 		if DataMap != nil && fmt.Sprintf("%v", DataMap) != "[map[]]" {
 			wge.SetLimit(-1)
 			for _, Data := range DataMap {
 				Data := Data
-				wge.Go(func () error{
+				wge.Go(func() error {
 					resultadoAux := make(map[string]interface{})
 					var formacion map[string]interface{}
 					if err := json.Unmarshal([]byte(Data["Dato"].(string)), &formacion); err == nil {
 						if formacion["ProgramaAcademico"] != "colegio" {
+							mutex.Lock()
 							resultadoAux["Id"] = Data["Id"]
 							resultadoAux["Nit"] = formacion["NitUniversidad"]
 							resultadoAux["Documento"] = formacion["DocumentoId"]
 							resultadoAux["FechaInicio"] = formacion["FechaInicio"]
 							resultadoAux["FechaFinalizacion"] = formacion["FechaFin"]
-	
+							mutex.Unlock()
+
 							endpoit := "datos_identificacion?query=TipoDocumentoId__Id:7,Numero:" + fmt.Sprintf("%v", formacion["NitUniversidad"])
-	
+
 							if strings.Contains(fmt.Sprintf("%v", formacion["NitUniversidad"]), "-") {
 								var auxId = strings.Split(fmt.Sprintf("%v", formacion["NitUniversidad"]), "-")
 								endpoit = "datos_identificacion?query=TipoDocumentoId__Id:7,Numero:" + auxId[0] + ",DigitoVerificacion:" + auxId[1]
 							}
-	
-							//GET para obtener el ID que relaciona las tablas tipo_documento y tercero
+
+							// GET para obtener el ID que relaciona las tablas tipo_documento y tercero
 							var IdTercero []map[string]interface{}
 							errIdTercero := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+endpoit, &IdTercero)
 							if errIdTercero == nil && fmt.Sprintf("%v", IdTercero[0]) != "map[]" && IdTercero[0]["Id"] != nil {
 								if IdTercero[0]["Status"] != "404" {
 									IdTerceroAux := IdTercero[0]["TerceroId"].(map[string]interface{})["Id"]
-	
+
 									// GET para traer el nombre de la universidad y el país
 									var Tercero []map[string]interface{}
 									errTercero := request.GetJson("http://"+beego.AppConfig.String("TercerosService")+"tercero?query=Id:"+fmt.Sprintf("%v", IdTerceroAux), &Tercero)
 									if errTercero == nil && fmt.Sprintf("%v", Tercero[0]) != "map[]" && Tercero[0]["Id"] != nil {
 										if Tercero[0]["Status"] != "404" {
+											mutex.Lock()
 											resultadoAux["NombreCompleto"] = Tercero[0]["NombreCompleto"]
+											mutex.Unlock()
+
 											var lugar map[string]interface{}
-	
-											//GET para traer los datos de la ubicación
+
+											// GET para traer los datos de la ubicación
 											errLugar := request.GetJson("http://"+beego.AppConfig.String("UbicacionesService")+"/relacion_lugares/jerarquia_lugar/"+fmt.Sprintf("%v", Tercero[0]["LugarOrigen"]), &lugar)
 											if errLugar == nil && fmt.Sprintf("%v", lugar) != "map[]" {
 												if lugar["Status"] != "404" {
+													mutex.Lock()
 													resultadoAux["Ubicacion"] = lugar["PAIS"].(map[string]interface{})["Nombre"]
+													mutex.Unlock()
 												} else {
+													mutex.Lock()
 													resultadoAux["Ubicacion"] = nil
-													/* errorGetAll = true
-													alertas = append(alertas, errLugar.Error())
-													alerta.Code = "400"
-													alerta.Type = "error"
-													alerta.Body = alertas
-													c.Data["json"] = map[string]interface{}{"Response": alerta} */
+													mutex.Unlock()
 												}
 											} else {
+												mutex.Lock()
 												resultadoAux["Ubicacion"] = nil
-												/* errorGetAll = true
-												alertas = append(alertas, "No data found")
-												alerta.Code = "404"
-												alerta.Type = "error"
-												alerta.Body = alertas
-												c.Data["json"] = map[string]interface{}{"Response": alerta} */
+												mutex.Unlock()
 											}
 										} else {
 											return errTercero
@@ -500,26 +498,30 @@ func GetFormacionAcademicaByIdTercero(idTercero string) (APIResponseDTO requestr
 							} else {
 								return errors.New("No data found")
 							}
-	
+
 							NumProyecto := fmt.Sprintf("%v", formacion["ProgramaAcademico"])
-	
+
 							var ProyectoV2 map[string]interface{}
 							errProyectoV2 := request.GetJson("http://"+beego.AppConfig.String("ParametroService")+"parametro?query=TipoParametroId__Id:60,Id:"+fmt.Sprintf("%v", NumProyecto)+"&limit=0", &ProyectoV2)
 							if errProyectoV2 == nil && ProyectoV2["Status"] == "200" && fmt.Sprintf("%v", ProyectoV2["Data"]) != "[map[]]" {
+								mutex.Lock()
 								resultadoAux["ProgramaAcademico"] = map[string]interface{}{
 									"Id":     NumProyecto,
 									"Nombre": ProyectoV2["Data"].([]interface{})[0].(map[string]interface{})["Nombre"],
 								}
+								mutex.Unlock()
 							} else {
-								//GET para consultar el proyecto curricular Modo antiguo
+								// GET para consultar el proyecto curricular Modo antiguo
 								var Proyecto []map[string]interface{}
 								errProyecto := request.GetJson("http://"+beego.AppConfig.String("ProyectoAcademicoService")+"proyecto_academico_institucion?query=Id:"+fmt.Sprintf("%v", NumProyecto)+"&limit=0", &Proyecto)
 								if errProyecto == nil && fmt.Sprintf("%v", Proyecto[0]) != "map[]" && Proyecto[0]["Id"] != nil {
 									if Proyecto[0]["Status"] != "404" {
+										mutex.Lock()
 										resultadoAux["ProgramaAcademico"] = map[string]interface{}{
 											"Id":     NumProyecto,
 											"Nombre": Proyecto[0]["Nombre"],
 										}
+										mutex.Unlock()
 									} else {
 										return errProyecto
 									}
@@ -527,7 +529,7 @@ func GetFormacionAcademicaByIdTercero(idTercero string) (APIResponseDTO requestr
 									return errors.New("No data found")
 								}
 							}
-							
+
 							mutex.Lock()
 							resultado = append(resultado, resultadoAux)
 							mutex.Unlock()


### PR DESCRIPTION
### Solucionar problema de concurrencia

- Añadido sync.Mutex para proteger el acceso concurrente a los mapas.
- Añadido bloqueo (mutex.Lock) y desbloqueo (mutex.Unlock) alrededor de todas las operaciones de escritura a los mapas compartidos.
- Se asegura que todas las escrituras concurrentes a resultadoAux y resultado estén protegidas por el mutex.
- Se evita el error de "concurrent map writes" al proteger el acceso a los mapas compartidos.
---
udistrital/sga_documentacion#375