### PR TITLE
hotfix: logs notificacion correo, udistrital/sga_documentacion#716

### DIFF
--- a/helpers/notificacion_correo.go
+++ b/helpers/notificacion_correo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/logs"
 	"github.com/udistrital/inscripcion_mid/models"
 	"github.com/udistrital/inscripcion_mid/utils"
 	"github.com/udistrital/utils_oas/request"
@@ -13,8 +14,9 @@ func EnviarNotificacionObservacionInscripcion(dataInscripcion map[string]interfa
 	// logs.Info("Entra al envío de correo")
 	var tercero models.TerceroId
 	errPersona := request.GetJson(beego.AppConfig.String("TercerosService")+"tercero/"+fmt.Sprint(dataInscripcion["PersonaId"]), &tercero)
-	// fmt.Println(errPersona)
-	// fmt.Println("")
+	logs.Info("datos del tercero")
+	fmt.Println(tercero)
+	fmt.Println("")
 	if errPersona == nil {
 		bodyEmail := map[string]interface{}{
 			"Html": map[string]interface{}{
@@ -24,9 +26,10 @@ func EnviarNotificacionObservacionInscripcion(dataInscripcion map[string]interfa
 				"Data": "Novedad en Inscripción solicitada",
 			},
 		}
-		// fmt.Println(bodyEmail)
-		// fmt.Println(tercero.UsuarioWSO2)
-		// fmt.Println("")
+		logs.Info("Cuerpo del correo")
+		fmt.Println(bodyEmail)
+		fmt.Println(tercero.UsuarioWSO2)
+		fmt.Println("")
 		utils.SendNotificacionCambioEstadoSolicitud(bodyEmail, tercero.UsuarioWSO2)
 	}
 }

--- a/services/inscripciones.service.go
+++ b/services/inscripciones.service.go
@@ -1254,6 +1254,9 @@ func ActualizarInscripcion(infoComp map[string]interface{}, id float64) (map[str
 			// si el estado es: "inscrito con Observación" enviar correo indicando al
 			if nuevoEstado != nil && *nuevoEstado == estadoInscritoObservacion {
 				// logs.Info("El nuevo estado es inscrito con observación")
+				logs.Info("información recibida")
+				fmt.Println(infoComp)
+				fmt.Println("")
 				helpers.EnviarNotificacionObservacionInscripcion(infoComp)
 			}
 			var respCambio map[string]interface{}

--- a/utils/notificacion_service.go
+++ b/utils/notificacion_service.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/astaxie/beego"
@@ -54,6 +55,9 @@ func SendNotificacionCambioEstadoSolicitud(data map[string]interface{}, email st
 		SourceEmail: "notificacionessga@udistrital.edu.co",
 		SourceName:  "Notificaciones inscripciones",
 	}
+	logs.Info("Objeto correo")
+	fmt.Println(mail)
+	fmt.Println("")
 
 	return SendEmail(mail)
 }


### PR DESCRIPTION
Se agregan logs de seguimiento para identificar porqué no se envían correos en ambientes nube.