### PR TITLE
hotfix: logs notificacion correo, udistrital/sga_documentacion#716

### DIFF
--- a/utils/notificacion_service.go
+++ b/utils/notificacion_service.go
@@ -25,6 +25,9 @@ func SendTemplatedEmail(inputemailtemplated map[string]interface{}) (result erro
 func SendEmail(inputMail models.Correo) (result error) {
 	// Envio de mail
 	var resultadoPost map[string]interface{}
+	logs.Info("Endpoint de notificación")
+	fmt.Println(beego.AppConfig.String("notificacionService") + "email/enviar_email")
+	fmt.Println("")
 	errSendEmail := request.SendJsonEscapeUnicode(beego.AppConfig.String("notificacionService")+"email/enviar_email", "POST", &resultadoPost, inputMail)
 	if errSendEmail == nil {
 		logs.Info("Correo enviado, respuesta de Notificaciones service:")


### PR DESCRIPTION
Se agregan logs de seguimiento para identificar porqué no se envían correos en ambientes nube.